### PR TITLE
Add missing params ddoc to parser factory function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
 
 script:
   - make build-all
+  - make docs
   - if [ ${PRIMARY} = "true" ]; then make unittest-cov; else make unittest; fi
 
 after_success:

--- a/source/std/experimental/xml/parser.d
+++ b/source/std/experimental/xml/parser.d
@@ -315,6 +315,8 @@ struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No
 +       preserveWhitespace = whether the returned `Parser` shall skip element content
 +                            whitespace or return it as text nodes
 +       lexer = the _lexer to build this `Parser` from
++       handler = optional error-handling delegate (if not provided, the default will
++                 assert on any XML syntax error)
 +
 +   Returns:
 +   A `Parser` instance initialized with the given lexer


### PR DESCRIPTION
The `handler` parameter was presumably omitted as optional, but this causes docs/ddox builds to fail (including for downstreams that have `std.experimental.xml` as a dependency).