### PR TITLE
Update CI to use LDC v1.1.0 instead of v1.1.0-beta3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ matrix:
   include:
     - d: dmd
       env: PRIMARY="true"
-    - d: ldc-1.1.0-beta3
+    - d: ldc-1.1.0
       env: PRIMARY="false"
   allow_failures:
-    - d: ldc-1.1.0-beta3
+    - d: ldc-1.1.0
 
 script:
   - make build-all


### PR DESCRIPTION
The use of this beta seems an odd choice for CI, especially as the LDC version is quite old.  This patch updates it to the final release of that minor LDC version.